### PR TITLE
Split CPU class in abstract base CPUBase and specific ISS_CPU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ add_library(${PROJECT_NAME} SHARED
     src/tlm/base/vp.cpp
     src/tlm/base/soc.cpp
 
-    src/tlm/generic/cpu.cpp
+    src/tlm/generic/cpu_base.cpp
+    src/tlm/generic/iss_cpu.cpp
     src/tlm/generic/reset_gen.cpp
     src/tlm/generic/bus.cpp
     src/tlm/generic/mem.cpp

--- a/examples/barebone_vp/barebone_soc.cpp
+++ b/examples/barebone_vp/barebone_soc.cpp
@@ -39,7 +39,7 @@ void BareboneSoC::setup()
 
     addMem(barebone_soc_params_.mem_params_.name_, std::move(barebone_soc_params_.mem_params_), bus_name);
 
-    etiss_sc::CPU *cpu{ nullptr };
+    etiss_sc::CPUBase *cpu{ nullptr };
     try
     {
         cpu = cpus_.at(cpu_name).get();

--- a/include/etiss-sc/tlm/base/soc.h
+++ b/include/etiss-sc/tlm/base/soc.h
@@ -34,7 +34,7 @@
 #include "scc/tlm_target_bfs.h"
 
 #include "etiss-sc/utils/xreport.hpp"
-#include "etiss-sc/tlm/generic/cpu.h"
+#include "etiss-sc/tlm/generic/iss_cpu.h"
 #include "etiss-sc/tlm/generic/bus.h"
 #include "etiss-sc/tlm/generic/mem.h"
 
@@ -62,7 +62,7 @@ class SoC : public sc_core::sc_module
     SoC(sc_core::sc_module_name, SoCParams &&);
     virtual ~SoC() = default;
 
-    const CPU &getCPU(std::string) const;
+    const CPUBase &getCPU(std::string) const;
     const Mem *getMem(std::string) const;
     sc_core::sc_signal<bool> *getIRQ(std::string, size_t);
     virtual void setup();
@@ -123,16 +123,16 @@ class SoC : public sc_core::sc_module
 
   protected:
     SoCParams soc_params_{};
-    std::map<std::string, std::unique_ptr<CPU>> cpus_{};
+    std::map<std::string, std::unique_ptr<CPUBase>> cpus_{};
     std::map<std::string, std::unique_ptr<Bus>> buses_{};
     std::map<std::string, std::unique_ptr<Mem>> mems_{};
     std::map<std::string, std::unique_ptr<scc::tlm_target_bfs_base<etiss_sc::SoC>>> pers_{};
-    std::map<const CPU *, std::vector<sc_core::sc_signal<bool>>> irqs_{};
+    std::map<const CPUBase *, std::vector<sc_core::sc_signal<bool>>> irqs_{};
 
     std::vector<std::unique_ptr<ELFIO::elfio>> elf_readers_{};
 
     virtual void addBus(std::string name, BusParams &&bus_params);
-    virtual const CPU *addCPU(CPUFactory *cpu_factory, std::string bus_name);
+    virtual const CPUBase *addCPU(CPUFactory *cpu_factory, std::string bus_name);
     virtual const Mem *addMem(std::string name, MemParams &&mem_params, std::string bus_name);
     void burnMem(Mem *);
 

--- a/include/etiss-sc/tlm/generic/cpu_base.h
+++ b/include/etiss-sc/tlm/generic/cpu_base.h
@@ -59,7 +59,7 @@ class CPUBase : public sc_core::sc_module
     virtual ~CPUBase() = default;
 
     virtual void setup() = 0;
-    virtual void setupDMI(uint64_t addr); // should be overloaded if CPU supports DMI
+    virtual void setupDMI(uint64_t addr) {}; // should be overloaded if CPU supports DMI
     size_t getNumIRQs() const;
     virtual void bindIRQ(size_t id, sc_core::sc_signal<bool> &irq) const = 0;
 

--- a/include/etiss-sc/tlm/generic/cpu_base.h
+++ b/include/etiss-sc/tlm/generic/cpu_base.h
@@ -26,7 +26,7 @@
 #include <string>
 
 #include "systemc"
-#include "tlm_utils/simple_initiator_socket.h"
+#include "tlm.h"
 
 #include "etiss-sc/utils/common.h"
 #include "etiss-sc/utils/xreport.hpp"

--- a/include/etiss-sc/tlm/generic/cpu_base.h
+++ b/include/etiss-sc/tlm/generic/cpu_base.h
@@ -53,7 +53,6 @@ class CPUBase : public sc_core::sc_module
 
     std::unique_ptr<tlm::tlm_initiator_socket<>> data_sock_i_{ nullptr };  ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
     std::unique_ptr<tlm::tlm_initiator_socket<>> instr_sock_i_{ nullptr }; ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
-    static size_t id;
 
     CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params);
     virtual ~CPUBase() = default;
@@ -65,10 +64,15 @@ class CPUBase : public sc_core::sc_module
 
     virtual void final() {};
 
+    int get_cpu_id() { return cpu_id_; }
+
   protected:
     // Every subclass must have its own core
     // std::shared_ptr<CORE_TYPE> core_{ nullptr }; 
     CPUParams cpu_params_{};
+
+    static int id;
+    int cpu_id_;
 };
 
 } // namespace etiss_sc

--- a/include/etiss-sc/tlm/generic/cpu_base.h
+++ b/include/etiss-sc/tlm/generic/cpu_base.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Chair of EDA, Technical University of Munich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file cpu_base.h
+/// @date 2022-05-30
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#ifndef __ETISS_SC_TLM_GENERIC_CPU_BASE_H__
+#define __ETISS_SC_TLM_GENERIC_CPU_BASE_H__
+
+#include <forward_list> // for systemc dmi
+#include <string>
+
+#include "systemc"
+#include "tlm_utils/simple_initiator_socket.h"
+
+#include "etiss-sc/utils/common.h"
+#include "etiss-sc/utils/xreport.hpp"
+
+#include "etiss/ETISS.h"
+
+namespace etiss_sc
+{
+class CPUParams
+{
+  public:
+    std::string name_{ "cpu" };
+    etiss::Initializer *etiss_init_{ nullptr };
+    size_t num_irqs_{ 0 };
+    etiss::InterruptType irq_handler_type_{ etiss::EDGE_TRIGGERED };
+};
+
+// abstract base class
+class CPUBase : public sc_core::sc_module
+{
+  public:
+    sc_core::sc_in<bool> rst_i_{ "reset_in" };
+    sc_core::sc_in<bool> clk_i_{ "clock_in" };
+
+    std::unique_ptr<tlm::tlm_initiator_socket<>> data_sock_{ nullptr };  ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
+    std::unique_ptr<tlm::tlm_initiator_socket<>> instr_sock_{ nullptr }; ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
+    static size_t id;
+
+    CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params);
+    virtual ~CPUBase() = default;
+
+    virtual void setup() = 0;
+    virtual void setupDMI(uint64_t addr); // should be overloaded if CPU supports DMI
+    size_t getNumIRQs() const;
+    virtual void bindIRQ(size_t id, sc_core::sc_signal<bool> &irq) const = 0;
+
+    virtual void final() {};
+
+  protected:
+    // Every subclass must have its own core
+    // std::shared_ptr<CORE_TYPE> core_{ nullptr }; 
+    CPUParams cpu_params_{};
+};
+
+} // namespace etiss_sc
+
+#endif // __ETISS_SC_TLM_GENERIC_CPU_BASE_H__

--- a/include/etiss-sc/tlm/generic/cpu_base.h
+++ b/include/etiss-sc/tlm/generic/cpu_base.h
@@ -51,8 +51,8 @@ class CPUBase : public sc_core::sc_module
     sc_core::sc_in<bool> rst_i_{ "reset_in" };
     sc_core::sc_in<bool> clk_i_{ "clock_in" };
 
-    std::unique_ptr<tlm::tlm_initiator_socket<>> data_sock_{ nullptr };  ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
-    std::unique_ptr<tlm::tlm_initiator_socket<>> instr_sock_{ nullptr }; ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
+    std::unique_ptr<tlm::tlm_initiator_socket<>> data_sock_i_{ nullptr };  ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
+    std::unique_ptr<tlm::tlm_initiator_socket<>> instr_sock_i_{ nullptr }; ///< tlm_initiator_socket is hierarchically bound to the simple_initiator_socket of the core (given the core is not an ETISS core and has a simple_initiator_socket)
     static size_t id;
 
     CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params);

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -100,6 +100,8 @@ class ISS_CPU final : public CPUBase, public ETISS_System
     virtual etiss_int32 systemCallDbgWrite(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length);
 
     int32_t get_etiss_status(void) { return etiss_status_; }
+    std::shared_ptr<etiss::VirtualStruct> get_core_struct(void) { return etiss_core_->getStruct(); }
+    ETISS_CPU * get_etiss_cpu_struct(void) { return etiss_core_->getState(); }
 
   private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -101,6 +101,8 @@ class ISS_CPU final : public CPUBase, public ETISS_System
 
     int32_t get_etiss_status(void) { return etiss_status_; }
 
+    sc_core::sc_in<bool> pause_cpu_i_{ "pause_cpu" };
+
   private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };
     std::shared_ptr<etiss::InterruptHandler> irq_handler_{ nullptr };

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -100,10 +100,16 @@ class ISS_CPU final : public CPUBase, public ETISS_System
 
     int32_t get_etiss_status(void) { return etiss_status_; }
 
+    void freeze_cpu() { freeze_cpu_ = true; std::cout << "        +++ iss_cpu frozen" << std::endl; };
+    void wake_up_cpu() { wake_up_cpu_.notify(); std::cout << "        +++ iss_cpu woken up" << std::endl; };
+
   private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };
     std::shared_ptr<etiss::InterruptHandler> irq_handler_{ nullptr };
     std::shared_ptr<ResetTerminatePlugin> reset_terminate_handler_{ nullptr };
+
+    sc_core::sc_event wake_up_cpu_{ "wake_up_cpu_event" };
+    bool freeze_cpu_{ false };
     
     std::forward_list<tlm::tlm_dmi> dmi_objects_{};
     uint64_t quantum_{ 0 };

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -101,7 +101,8 @@ class ISS_CPU final : public CPUBase, public ETISS_System
 
     int32_t get_etiss_status(void) { return etiss_status_; }
 
-    sc_core::sc_in<bool> pause_cpu_i_{ "pause_cpu" };
+    void register_event_pause_cpu(sc_core::sc_event& event);
+    void register_event_resume_cpu(sc_core::sc_event& event);
 
   private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };
@@ -119,6 +120,10 @@ class ISS_CPU final : public CPUBase, public ETISS_System
         TERMINATED
     } status_{};
     int32_t etiss_status_{ etiss::RETURNCODE::NOERROR };
+
+    bool cpu_paused_{ false };
+    sc_core::sc_event* pause_cpu_event_{ nullptr };
+    sc_core::sc_event* resume_cpu_event_{ nullptr };
 
     virtual void resetMethod();
     virtual void execute();

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -23,6 +23,7 @@
 #define __ETISS_SC_TLM_GENERIC_ISS_CPU_H__
 
 #include "etiss-sc/tlm/generic/cpu_base.h"
+#include "tlm_utils/simple_initiator_socket.h"
 
 #include <string>
 #include <vector>

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Chair of EDA, Technical University of Munich
+ * Copyright 2022 Chair of EDA, Technical University of Munich
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,40 +15,26 @@
  */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-/// @file cpu.h
-/// @date 2019-03-09
+/// @file iss_cpu.h
+/// @date 2022-05-30
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#ifndef __ETISS_SC_TLM_GENERIC_CPU_H__
-#define __ETISS_SC_TLM_GENERIC_CPU_H__
+#ifndef __ETISS_SC_TLM_GENERIC_ISS_CPU_H__
+#define __ETISS_SC_TLM_GENERIC_ISS_CPU_H__
 
-#include <forward_list> // for systemc dmi
-#include <map>
-#include <memory>
+#include "etiss-sc/tlm/generic/cpu_base.h"
+
 #include <string>
 #include <vector>
 
-#include "etiss/ETISS.h"
-#include "systemc"
-#include "tlm_utils/simple_initiator_socket.h"
-
-#include "etiss-sc/utils/common.h"
-#include "etiss-sc/utils/xreport.hpp"
 
 namespace etiss_sc
 {
-class CPUParams
-{
-  public:
-    std::string name_{ "cpu" };
-    etiss::Initializer *etiss_init_{ nullptr };
-    size_t num_irqs_{ 0 };
-    etiss::InterruptType irq_handler_type_{ etiss::EDGE_TRIGGERED };
-};
 
-class CPU : public ETISS_System, public sc_core::sc_module
+// Note: ISS_CPU is a systemc CPU with an etiss::CPUCore and ETISS_CPU is a struct from etiss
+class ISS_CPU final : public CPUBase, public ETISS_System
 {
-    SC_HAS_PROCESS(CPU);
+    SC_HAS_PROCESS(ISS_CPU);
 
   protected:
     class IRQ : public sc_core::sc_module
@@ -92,22 +78,16 @@ class CPU : public ETISS_System, public sc_core::sc_module
         bool reset_{ false };
         bool terminate_{ false };
     };
+    
 
   public:
-    using outcome_t = std::map<std::string, bool>;
+    std::vector<std::unique_ptr<IRQ>> irq_i_{}; ///< Interrupt vector
 
-    sc_core::sc_in<bool> rst_i_{ "reset_in" };
-    std::unique_ptr<tlm_utils::simple_initiator_socket<CPU>> data_sock_i_{ nullptr };
-    std::unique_ptr<tlm_utils::simple_initiator_socket<CPU>> instr_sock_i_{ nullptr };
-    std::vector<std::unique_ptr<IRQ>> irq_i_{};
-    static size_t id;
+    ISS_CPU(sc_core::sc_module_name name, CPUParams &&cpu_params);
+    virtual ~ISS_CPU();
 
-    CPU(sc_core::sc_module_name name, CPUParams &&cpu_params);
-    virtual ~CPU();
-
-    virtual void setup();
-    virtual void setupDMI(uint64_t addr);
-    size_t getNumIRQs() const;
+    void setup();
+    void setupDMI(uint64_t addr) override;
     void bindIRQ(size_t id, sc_core::sc_signal<bool> &irq) const;
 
     virtual void systemCallSyncTime(ETISS_CPU *cpu);
@@ -120,14 +100,15 @@ class CPU : public ETISS_System, public sc_core::sc_module
 
     int32_t get_etiss_status(void) { return etiss_status_; }
 
-  protected:
-    CPUParams cpu_params_{};
+  private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };
     std::shared_ptr<etiss::InterruptHandler> irq_handler_{ nullptr };
     std::shared_ptr<ResetTerminatePlugin> reset_terminate_handler_{ nullptr };
+    
     std::forward_list<tlm::tlm_dmi> dmi_objects_{};
     uint64_t quantum_{ 0 };
     tlm::tlm_generic_payload payload_{};
+    
     enum class CPUStatus
     {
         ACTIVE,
@@ -135,30 +116,28 @@ class CPU : public ETISS_System, public sc_core::sc_module
         TERMINATED
     } status_{};
     int32_t etiss_status_{ etiss::RETURNCODE::NOERROR };
-    std::vector<uint32_t> dwrites_{};
 
     virtual void resetMethod();
     virtual void execute();
-    void transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
-                     tlm_utils::simple_initiator_socket<CPU> &socket);
-    uint32_t dbgTransaction(uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
-                            tlm_utils::simple_initiator_socket<CPU> &socket);
-    void dmiAccess(uint8_t *dst, uint8_t *src, unsigned len, bool flip_endianness = false);
+
+    void transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd, tlm::tlm_initiator_socket<> &socket);
+    virtual uint32_t dbgTransaction( uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd, tlm::tlm_initiator_socket<> &socket);
+    virtual void dmiAccess(uint8_t *dst, uint8_t *src, unsigned len, bool flip_endianness = false);
+    
     sc_core::sc_time getTimeOffset(ETISS_CPU *cpu);
     void updateCPUTime(ETISS_CPU *cpu, const sc_core::sc_time &time_offset);
     void updateSystemCTime(sc_core::sc_time &time_offset);
     void configurePayload(uint64_t addr, tlm::tlm_command cmd, uint8_t *buffer = nullptr, uint32_t length = 0);
 };
 
-// abstract class
-class CPUFactory : public Factory<CPU>
+class CPUFactory : public Factory<ISS_CPU>
 {
   public:
     explicit CPUFactory(const etiss_sc::Config &cfg, etiss::Initializer *etiss_init);
     std::string get_name() { return cpu_params_.name_; }
 
   protected:
-    using Factory<CPU>::genHelper;
+    using Factory<ISS_CPU>::genHelper;
     CPUParams cpu_params_{};
 
     void initParams() override;
@@ -167,4 +146,4 @@ class CPUFactory : public Factory<CPU>
 
 } // namespace etiss_sc
 
-#endif // __ETISS_SC_TLM_GENERIC_CPU_H__
+#endif // __ETISS_SC_TLM_GENERIC_ISS_CPU_H__

--- a/include/etiss-sc/tlm/generic/iss_cpu.h
+++ b/include/etiss-sc/tlm/generic/iss_cpu.h
@@ -101,9 +101,6 @@ class ISS_CPU final : public CPUBase, public ETISS_System
 
     int32_t get_etiss_status(void) { return etiss_status_; }
 
-    void register_event_pause_cpu(sc_core::sc_event& event);
-    void register_event_resume_cpu(sc_core::sc_event& event);
-
   private:
     std::shared_ptr<etiss::CPUCore> etiss_core_{ nullptr };
     std::shared_ptr<etiss::InterruptHandler> irq_handler_{ nullptr };
@@ -120,10 +117,6 @@ class ISS_CPU final : public CPUBase, public ETISS_System
         TERMINATED
     } status_{};
     int32_t etiss_status_{ etiss::RETURNCODE::NOERROR };
-
-    bool cpu_paused_{ false };
-    sc_core::sc_event* pause_cpu_event_{ nullptr };
-    sc_core::sc_event* resume_cpu_event_{ nullptr };
 
     virtual void resetMethod();
     virtual void execute();

--- a/src/tlm/base/soc.cpp
+++ b/src/tlm/base/soc.cpp
@@ -28,9 +28,9 @@ etiss_sc::SoC::SoC(sc_core::sc_module_name name, etiss_sc::SoCParams &&soc_param
 {
 }
 
-const etiss_sc::CPU &etiss_sc::SoC::getCPU(std::string name) const
+const etiss_sc::CPUBase &etiss_sc::SoC::getCPU(std::string name) const
 {
-    CPU *cpu{ nullptr };
+    CPUBase *cpu{ nullptr };
     try
     {
         cpu = cpus_.at(name).get();
@@ -60,7 +60,7 @@ const etiss_sc::Mem *etiss_sc::SoC::getMem(std::string name) const
 
 sc_core::sc_signal<bool> *etiss_sc::SoC::getIRQ(std::string cpu_name, size_t num)
 {
-    CPU *cpu{ nullptr };
+    CPUBase *cpu{ nullptr };
     try
     {
         cpu = cpus_.at(cpu_name).get();
@@ -81,7 +81,7 @@ void etiss_sc::SoC::setup()
     addBus(bus_name, std::move(soc_params_.bus_params_));
     addCPU(soc_params_.cpu_factory_.get(), bus_name);
 
-    const CPU *cpu{ nullptr };
+    const CPUBase *cpu{ nullptr };
     try
     {
         cpu = &getCPU(cpu_name);
@@ -139,7 +139,7 @@ void etiss_sc::SoC::addBus(std::string name, BusParams &&bus_params)
     buses_.insert(std::make_pair(name, std::move(bus)));
 }
 
-const etiss_sc::CPU *etiss_sc::SoC::addCPU(CPUFactory *cpu_factory, std::string bus_name)
+const etiss_sc::CPUBase *etiss_sc::SoC::addCPU(CPUFactory *cpu_factory, std::string bus_name)
 {
     auto cpu_name = soc_params_.cpu_factory_.get()->get_name();
     auto cpu = cpu_factory->create(cpu_name.c_str());
@@ -154,8 +154,8 @@ const etiss_sc::CPU *etiss_sc::SoC::addCPU(CPUFactory *cpu_factory, std::string 
     {
         XREPORT_FATAL("bus not found in SoC::addCPU()");
     }
-    bus->connectMaster(cpu->instr_sock_i_.get());
-    bus->connectMaster(cpu->data_sock_i_.get());
+    bus->connectMaster(cpu->instr_sock_.get());
+    bus->connectMaster(cpu->data_sock_.get());
 
     cpus_.insert(std::make_pair(cpu_name, std::move(cpu)));
     return cpus_[cpu_name].get();

--- a/src/tlm/base/soc.cpp
+++ b/src/tlm/base/soc.cpp
@@ -154,8 +154,8 @@ const etiss_sc::CPUBase *etiss_sc::SoC::addCPU(CPUFactory *cpu_factory, std::str
     {
         XREPORT_FATAL("bus not found in SoC::addCPU()");
     }
-    bus->connectMaster(cpu->instr_sock_.get());
-    bus->connectMaster(cpu->data_sock_.get());
+    bus->connectMaster(cpu->instr_sock_i_.get());
+    bus->connectMaster(cpu->data_sock_i_.get());
 
     cpus_.insert(std::make_pair(cpu_name, std::move(cpu)));
     return cpus_[cpu_name].get();

--- a/src/tlm/generic/cpu_base.cpp
+++ b/src/tlm/generic/cpu_base.cpp
@@ -28,11 +28,6 @@ etiss_sc::CPUBase::CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params)
     , cpu_params_{ std::move(cpu_params) }
 {}
 
-void etiss_sc::CPUBase::setupDMI(uint64_t addr)
-{
-    std::cout << "---------------------------- [Lasse] im iss cpu dmi setup: " << std::endl;
-}
-
 size_t etiss_sc::CPUBase::getNumIRQs() const
 {
     return cpu_params_.num_irqs_;

--- a/src/tlm/generic/cpu_base.cpp
+++ b/src/tlm/generic/cpu_base.cpp
@@ -21,16 +21,17 @@
 
 #include "etiss-sc/tlm/generic/cpu_base.h"
 
-size_t etiss_sc::CPUBase::id = 0;
+int etiss_sc::CPUBase::id = 0;
 
 etiss_sc::CPUBase::CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params)
     : sc_core::sc_module(name)
     , cpu_params_{ std::move(cpu_params) }
+    , cpu_id_(CPUBase::id++)
 {}
 
 void etiss_sc::CPUBase::setupDMI(uint64_t addr)
 {
-    std::cout << "---------------------------- [Lasse] im iss cpu dmi setup: " << std::endl;
+    std::cout << "---------------------------- ERROR: in setup DMI in cpu_base.cpp " << std::endl;
 }
 
 size_t etiss_sc::CPUBase::getNumIRQs() const

--- a/src/tlm/generic/cpu_base.cpp
+++ b/src/tlm/generic/cpu_base.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Chair of EDA, Technical University of Munich
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// @file cpu_base.cpp
+/// @date 2022-05-30
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "etiss-sc/tlm/generic/cpu_base.h"
+
+size_t etiss_sc::CPUBase::id = 0;
+
+etiss_sc::CPUBase::CPUBase(sc_core::sc_module_name name, CPUParams &&cpu_params)
+    : sc_core::sc_module(name)
+    , cpu_params_{ std::move(cpu_params) }
+{}
+
+void etiss_sc::CPUBase::setupDMI(uint64_t addr)
+{
+    std::cout << "---------------------------- [Lasse] im iss cpu dmi setup: " << std::endl;
+}
+
+size_t etiss_sc::CPUBase::getNumIRQs() const
+{
+    return cpu_params_.num_irqs_;
+}

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -177,8 +177,8 @@ etiss_sc::ISS_CPU::ISS_CPU(sc_core::sc_module_name name, CPUParams &&cpu_params)
     dont_initialize();
     sensitive << rst_i_;
 
-    data_sock_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("data_socket");
-    instr_sock_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("instr_socket");
+    data_sock_i_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("data_socket");
+    instr_sock_i_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("instr_socket");
 
     this->iread = system_call_iread;
     this->iwrite = system_call_iwrite;
@@ -263,7 +263,7 @@ void etiss_sc::ISS_CPU::setupDMI(uint64_t addr)
     std::cout << "---------------------------- [Lasse] im iss cpu dmi setup: " << std::endl;
     dmi_objects_.push_front(tlm::tlm_dmi());
     configurePayload(addr, tlm::TLM_READ_COMMAND);
-    if (!((*data_sock_)->get_direct_mem_ptr(payload_, dmi_objects_.front()) && dmi_objects_.front().get_dmi_ptr()))
+    if (!((*data_sock_i_)->get_direct_mem_ptr(payload_, dmi_objects_.front()) && dmi_objects_.front().get_dmi_ptr()))
     {
         dmi_objects_.pop_front();
         XREPORT_FATAL("DMI not successful in CPU::setupDMI()");
@@ -292,7 +292,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr
     }
 
     std::vector<uint8_t> buffer(length);
-    transaction(cpu, addr, buffer.data(), length, tlm::TLM_READ_COMMAND, *instr_sock_);
+    transaction(cpu, addr, buffer.data(), length, tlm::TLM_READ_COMMAND, *instr_sock_i_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -310,7 +310,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallIWrite(ETISS_CPU *cpu, etiss_uint64 add
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_i_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -327,7 +327,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallDRead(ETISS_CPU *cpu, etiss_uint64 addr
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_READ_COMMAND, *data_sock_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_READ_COMMAND, *data_sock_i_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -345,7 +345,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 add
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *data_sock_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *data_sock_i_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -356,7 +356,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 add
 
 etiss_int32 etiss_sc::ISS_CPU::systemCallDbgRead(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_READ_COMMAND, *instr_sock_);
+    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_READ_COMMAND, *instr_sock_i_);
     if (response_len != length)
     {
         return etiss::RETURNCODE::IBUS_READ_ERROR;
@@ -367,7 +367,7 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallDbgRead(etiss_uint64 addr, etiss_uint8 
 
 etiss_int32 etiss_sc::ISS_CPU::systemCallDbgWrite(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_);
+    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_i_);
     if (response_len != length)
     {
         return etiss::RETURNCODE::IBUS_WRITE_ERROR;

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -19,6 +19,8 @@
 /// @date 2022-05-30
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#define SC_INCLUDE_DYNAMIC_PROCESSES      // crucial for sc_spawn
+
 #include "etiss-sc/tlm/generic/iss_cpu.h"
 #include "etiss/fault/Stressor.h"
 #include "etiss-sc/utils/plugins.h"
@@ -375,6 +377,34 @@ etiss_int32 etiss_sc::ISS_CPU::systemCallDbgWrite(etiss_uint64 addr, etiss_uint8
     return etiss::RETURNCODE::NOERROR;
 }
 
+/************************ pause and resume logic ************************/
+
+void etiss_sc::ISS_CPU::register_event_pause_cpu(sc_core::sc_event& event)
+{
+    auto pause_cpu_action = [this]() { cpu_paused_ = true; };
+
+    pause_cpu_event_ = &event;
+    sc_core::sc_spawn_options options;
+    options.spawn_method();             // Spawned process shall be a method process
+    options.set_sensitivity(&event);    // Spawned process shall be sensitive to pause_cpu event
+    options.dont_initialize();
+    sc_core::sc_spawn(pause_cpu_action, "pause_cpu_action", &options);
+}
+
+void etiss_sc::ISS_CPU::register_event_resume_cpu(sc_core::sc_event& event)
+{
+    auto resume_cpu_action = [this]() { cpu_paused_ = false; };
+
+    resume_cpu_event_ = &event;
+    sc_core::sc_spawn_options options;
+    options.spawn_method();             // Spawned process shall be a method process
+    options.set_sensitivity(&event);    // Spawned process shall be sensitive to pause_cpu event
+    options.dont_initialize();
+    sc_core::sc_spawn(resume_cpu_action, "resume_cpu_action", &options);
+}
+
+/************************ reset and execute logic ***********************/
+
 void etiss_sc::ISS_CPU::resetMethod()
 {
     reset_terminate_handler_->reset(rst_i_.read());
@@ -400,6 +430,8 @@ void etiss_sc::ISS_CPU::execute()
 
     sc_core::sc_stop();
 }
+
+/***************************** transactions *****************************/
 
 void etiss_sc::ISS_CPU::transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
                                 tlm::tlm_initiator_socket<> &socket)
@@ -511,9 +543,16 @@ void etiss_sc::ISS_CPU::updateSystemCTime(sc_core::sc_time &time_offset)
     if (sc_core::sc_time_stamp() == sc_core::SC_ZERO_TIME ||
         time_offset > sc_core::sc_time{ static_cast<double>(quantum_), sc_core::SC_PS })
     {
-        if (pause_cpu_i_.read() == true)
+        if (cpu_paused_)
         {
-            wait(pause_cpu_i_.negedge_event());
+            if (resume_cpu_event_ == nullptr)
+            {
+                etiss::log(etiss::ERROR, "ISS CPU is paused but there is no resume event registered.");
+            }
+            else
+            {
+                wait(*resume_cpu_event_);
+            }
         }
         else
         {

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -225,7 +225,6 @@ void etiss_sc::ISS_CPU::setup()
 
     etiss::VirtualStruct::root()->mountStruct("core" + std::to_string(CPUBase::id), etiss_core_->getStruct());
 
-    CPUBase::id++;
     cpu_params_.etiss_init_->loadIniPlugins(etiss_core_);
     cpu_params_.etiss_init_->loadIniJIT(etiss_core_);
 

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Chair of EDA, Technical University of Munich
+ * Copyright 2022 Chair of EDA, Technical University of Munich
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,59 +15,62 @@
  */
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-/// @file cpu.cpp
-/// @date 2019-03-10
+/// @file iss_cpu.cpp
+/// @date 2022-05-30
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include "etiss-sc/tlm/generic/cpu.h"
+#include "etiss-sc/tlm/generic/iss_cpu.h"
 #include "etiss/fault/Stressor.h"
 #include "etiss-sc/utils/plugins.h"
 
-#define ID_ETISS_SC_CPU "etiss-sc: CPU"
+#define ID_ETISS_SC_ISS_CPU "etiss-sc: ISS_CPU"
 
 void system_call_syncTime(void *handle, ETISS_CPU *cpu)
 {
-    static_cast<etiss_sc::CPU *>(handle)->systemCallSyncTime(cpu);
+    static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallSyncTime(cpu);
 }
 
 etiss_int32 system_call_iread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallIRead(cpu, addr, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallIRead(cpu, addr, length);
 }
 
-etiss_int32 system_call_iwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer,
-                               etiss_uint32 length)
+etiss_int32 system_call_iwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallIWrite(cpu, addr, buffer, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallIWrite(cpu, addr, buffer, length);
 }
 
 etiss_int32 system_call_dread(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallDRead(cpu, addr, buffer, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallDRead(cpu, addr, buffer, length);
 }
 
-etiss_int32 system_call_dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer,
-                               etiss_uint32 length)
+etiss_int32 system_call_dwrite(void *handle, ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallDWrite(cpu, addr, buffer, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallDWrite(cpu, addr, buffer, length);
 }
 
 etiss_int32 system_call_dbg_read(void *handle, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallDbgRead(addr, buffer, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallDbgRead(addr, buffer, length);
 }
 
 etiss_int32 system_call_dbg_write(void *handle, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    return static_cast<etiss_sc::CPU *>(handle)->systemCallDbgWrite(addr, buffer, length);
+    return static_cast<etiss_sc::ISS_CPU *>(handle)->systemCallDbgWrite(addr, buffer, length);
 }
 
-etiss_sc::CPU::IRQ::IRQ(sc_core::sc_module_name name, size_t id, etiss::InterruptHandler *irq_handler)
+
+/************************************************************************
+ * ISS_CPU::IRQ                                                         *
+ ************************************************************************/
+
+etiss_sc::ISS_CPU::IRQ::IRQ(sc_core::sc_module_name name, size_t id, etiss::InterruptHandler *irq_handler)
     : sc_module(name), id_{ id }, irq_handler_{ irq_handler }
 {
     if (!irq_handler_)
     {
-        SC_REPORT_FATAL(ID_ETISS_SC_CPU, "invalid irq_handler passed in CPU::IRQ::IRQ()");
+        SC_REPORT_FATAL(ID_ETISS_SC_ISS_CPU, "invalid irq_handler passed in ISS_CPU::IRQ::IRQ()");
     }
 
     SC_METHOD(execute);
@@ -75,9 +78,8 @@ etiss_sc::CPU::IRQ::IRQ(sc_core::sc_module_name name, size_t id, etiss::Interrup
     dont_initialize();
 }
 
-void etiss_sc::CPU::IRQ::execute()
+void etiss_sc::ISS_CPU::IRQ::execute()
 {
-
     if (irq_i_.read())
     {
         irq_handler_->setLine(id_, true, static_cast<etiss::uint64>(sc_core::sc_time_stamp().to_seconds() * 1e12));
@@ -88,7 +90,12 @@ void etiss_sc::CPU::IRQ::execute()
     }
 }
 
-etiss_int32 etiss_sc::CPU::ResetTerminatePlugin::execute()
+
+/************************************************************************
+ * ISS_CPU::ResetTerminatePlugin                                                                    *
+ ************************************************************************/
+
+etiss_int32 etiss_sc::ISS_CPU::ResetTerminatePlugin::execute()
 {
     if (terminate_)
     {
@@ -118,7 +125,7 @@ etiss_int32 etiss_sc::CPU::ResetTerminatePlugin::execute()
     }
 }
 
-void etiss_sc::CPU::ResetTerminatePlugin::reset(bool value)
+void etiss_sc::ISS_CPU::ResetTerminatePlugin::reset(bool value)
 {
     switch (state_)
     {
@@ -147,20 +154,22 @@ void etiss_sc::CPU::ResetTerminatePlugin::reset(bool value)
         }
         break;
     default:
-        SC_REPORT_FATAL(ID_ETISS_SC_CPU, "undefined state in CPU::ResetTerminatePlugin::reset()");
+        SC_REPORT_FATAL(ID_ETISS_SC_ISS_CPU, "undefined state in ISS_CPU::ResetTerminatePlugin::reset()");
     }
 }
 
-void etiss_sc::CPU::ResetTerminatePlugin::terminate()
+void etiss_sc::ISS_CPU::ResetTerminatePlugin::terminate()
 {
     terminate_ = true;
 }
 
-size_t etiss_sc::CPU::id{ 0 };
 
-etiss_sc::CPU::CPU(sc_core::sc_module_name name, CPUParams &&cpu_params)
-    : sc_core::sc_module(name)
-    , cpu_params_{ std::move(cpu_params) }
+/************************************************************************
+ * ISS CPU                                                              *
+ ************************************************************************/
+
+etiss_sc::ISS_CPU::ISS_CPU(sc_core::sc_module_name name, CPUParams &&cpu_params)
+    : CPUBase(name, std::move(cpu_params))
     , quantum_{ etiss::cfg().get<uint64_t>("etiss.cpu_quantum_ps", 0) }
 {
     SC_THREAD(execute);
@@ -168,8 +177,8 @@ etiss_sc::CPU::CPU(sc_core::sc_module_name name, CPUParams &&cpu_params)
     dont_initialize();
     sensitive << rst_i_;
 
-    data_sock_i_ = std::make_unique<tlm_utils::simple_initiator_socket<CPU>>("data_socket");
-    instr_sock_i_ = std::make_unique<tlm_utils::simple_initiator_socket<CPU>>("instr_socket");
+    data_sock_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("data_socket");
+    instr_sock_ = std::make_unique<tlm_utils::simple_initiator_socket<CPUBase>>("instr_socket");
 
     this->iread = system_call_iread;
     this->iwrite = system_call_iwrite;
@@ -181,7 +190,7 @@ etiss_sc::CPU::CPU(sc_core::sc_module_name name, CPUParams &&cpu_params)
     handle = this;
 }
 
-etiss_sc::CPU::~CPU()
+etiss_sc::ISS_CPU::~ISS_CPU()
 {
     auto cpu_time = sc_core::sc_time{ static_cast<double>(etiss_core_->getState()->cpuTime_ps), sc_core::SC_PS };
     if (status_ == CPUStatus::ACTIVE)
@@ -195,12 +204,12 @@ etiss_sc::CPU::~CPU()
 
             if (status_ == CPUStatus::ACTIVE)
             {
-                XREPORT_FATAL("CPU stuck and not exiting properly in CPU::~CPU()");
+                XREPORT_FATAL("CPU stuck and not exiting properly in ISS_CPU::~ISS_CPU()");
             }
         }
         else
         {
-            XREPORT_FATAL("CPU stuck and not exited properly in CPU::~CPU()");
+            XREPORT_FATAL("CPU stuck and not exited properly in ISS_CPU::~ISS_CPU()");
         }
     }
 
@@ -208,18 +217,15 @@ etiss_sc::CPU::~CPU()
     etiss_core_->removePlugin(reset_terminate_handler_);
 }
 
-void etiss_sc::CPU::setup()
+void etiss_sc::ISS_CPU::setup()
 {
-    etiss_core_ =
-        etiss::CPUCore::create(etiss::cfg().get<std::string>("arch.cpu", ""), "core" + std::to_string(CPU::id));
+    etiss_core_ = etiss::CPUCore::create(etiss::cfg().get<std::string>("arch.cpu", ""), "core" + std::to_string(CPUBase::id));
 
-    if (!etiss_core_)
-    {
-        XREPORT_FATAL("failed to create ETISS-CPUCore in CPU::setup()");
-    }
-    etiss::VirtualStruct::root()->mountStruct("core" + std::to_string(CPU::id), etiss_core_->getStruct());
+    if (!etiss_core_) XREPORT_FATAL("failed to create ETISS-CPUCore in ISS_CPU::setup()");
 
-    CPU::id++;
+    etiss::VirtualStruct::root()->mountStruct("core" + std::to_string(CPUBase::id), etiss_core_->getStruct());
+
+    CPUBase::id++;
     cpu_params_.etiss_init_->loadIniPlugins(etiss_core_);
     cpu_params_.etiss_init_->loadIniJIT(etiss_core_);
 
@@ -252,39 +258,32 @@ void etiss_sc::CPU::setup()
     etiss_core_->setTimer(etiss::cfg().get<bool>("etiss.timer", false));
 }
 
-void etiss_sc::CPU::setupDMI(uint64_t addr)
+void etiss_sc::ISS_CPU::setupDMI(uint64_t addr)
 {
+    std::cout << "---------------------------- [Lasse] im iss cpu dmi setup: " << std::endl;
     dmi_objects_.push_front(tlm::tlm_dmi());
     configurePayload(addr, tlm::TLM_READ_COMMAND);
-    if (!((*data_sock_i_)->get_direct_mem_ptr(payload_, dmi_objects_.front()) && dmi_objects_.front().get_dmi_ptr()))
+    if (!((*data_sock_)->get_direct_mem_ptr(payload_, dmi_objects_.front()) && dmi_objects_.front().get_dmi_ptr()))
     {
         dmi_objects_.pop_front();
         XREPORT_FATAL("DMI not successful in CPU::setupDMI()");
     }
 }
 
-size_t etiss_sc::CPU::getNumIRQs() const
+void etiss_sc::ISS_CPU::bindIRQ(size_t id, sc_core::sc_signal<bool> &irq) const
 {
-    return cpu_params_.num_irqs_;
-}
-
-void etiss_sc::CPU::bindIRQ(size_t id, sc_core::sc_signal<bool> &irq) const
-{
-    if (id >= irq_i_.size())
-    {
-        XREPORT_FATAL("not enough interrupts in CPU::bindIRQ()");
-    }
+    if (id >= irq_i_.size()) XREPORT_FATAL("not enough interrupts in ISS_CPU::bindIRQ()");
 
     irq_i_[id]->irq_i_.bind(irq);
 }
 
-void etiss_sc::CPU::systemCallSyncTime(ETISS_CPU *cpu)
+void etiss_sc::ISS_CPU::systemCallSyncTime(ETISS_CPU *cpu)
 {
     auto offset = getTimeOffset(cpu);
     updateSystemCTime(offset);
 }
 
-etiss_int32 etiss_sc::CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint32 length)
 {
     auto return_val = reset_terminate_handler_->execute();
     if (return_val != etiss::RETURNCODE::NOERROR)
@@ -293,7 +292,7 @@ etiss_int32 etiss_sc::CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr, et
     }
 
     std::vector<uint8_t> buffer(length);
-    transaction(cpu, addr, buffer.data(), length, tlm::TLM_READ_COMMAND, *instr_sock_i_);
+    transaction(cpu, addr, buffer.data(), length, tlm::TLM_READ_COMMAND, *instr_sock_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -303,7 +302,7 @@ etiss_int32 etiss_sc::CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr, et
     return etiss::RETURNCODE::NOERROR;
 }
 
-etiss_int32 etiss_sc::CPU::systemCallIWrite(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallIWrite(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
     auto return_val = reset_terminate_handler_->execute();
     if (return_val != etiss::RETURNCODE::NOERROR)
@@ -311,7 +310,7 @@ etiss_int32 etiss_sc::CPU::systemCallIWrite(ETISS_CPU *cpu, etiss_uint64 addr, e
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_i_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -320,7 +319,7 @@ etiss_int32 etiss_sc::CPU::systemCallIWrite(ETISS_CPU *cpu, etiss_uint64 addr, e
     return etiss::RETURNCODE::NOERROR;
 }
 
-etiss_int32 etiss_sc::CPU::systemCallDRead(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallDRead(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
     auto return_val = reset_terminate_handler_->execute();
     if (return_val != etiss::RETURNCODE::NOERROR)
@@ -328,7 +327,7 @@ etiss_int32 etiss_sc::CPU::systemCallDRead(ETISS_CPU *cpu, etiss_uint64 addr, et
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_READ_COMMAND, *data_sock_i_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_READ_COMMAND, *data_sock_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -338,7 +337,7 @@ etiss_int32 etiss_sc::CPU::systemCallDRead(ETISS_CPU *cpu, etiss_uint64 addr, et
     return etiss::RETURNCODE::NOERROR;
 }
 
-etiss_int32 etiss_sc::CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
     auto return_val = reset_terminate_handler_->execute();
     if (return_val != etiss::RETURNCODE::NOERROR)
@@ -346,7 +345,7 @@ etiss_int32 etiss_sc::CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 addr, e
         return return_val;
     }
 
-    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *data_sock_i_);
+    transaction(cpu, addr, buffer, length, tlm::TLM_WRITE_COMMAND, *data_sock_);
     auto response = payload_.get_response_status();
     if (response != tlm::TLM_OK_RESPONSE)
     {
@@ -355,9 +354,9 @@ etiss_int32 etiss_sc::CPU::systemCallDWrite(ETISS_CPU *cpu, etiss_uint64 addr, e
     return etiss::RETURNCODE::NOERROR;
 }
 
-etiss_int32 etiss_sc::CPU::systemCallDbgRead(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallDbgRead(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_READ_COMMAND, *instr_sock_i_);
+    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_READ_COMMAND, *instr_sock_);
     if (response_len != length)
     {
         return etiss::RETURNCODE::IBUS_READ_ERROR;
@@ -366,9 +365,9 @@ etiss_int32 etiss_sc::CPU::systemCallDbgRead(etiss_uint64 addr, etiss_uint8 *buf
     return etiss::RETURNCODE::NOERROR;
 }
 
-etiss_int32 etiss_sc::CPU::systemCallDbgWrite(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
+etiss_int32 etiss_sc::ISS_CPU::systemCallDbgWrite(etiss_uint64 addr, etiss_uint8 *buffer, etiss_uint32 length)
 {
-    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_i_);
+    auto response_len = dbgTransaction(addr, buffer, length, tlm::TLM_WRITE_COMMAND, *instr_sock_);
     if (response_len != length)
     {
         return etiss::RETURNCODE::IBUS_WRITE_ERROR;
@@ -376,12 +375,12 @@ etiss_int32 etiss_sc::CPU::systemCallDbgWrite(etiss_uint64 addr, etiss_uint8 *bu
     return etiss::RETURNCODE::NOERROR;
 }
 
-void etiss_sc::CPU::resetMethod()
+void etiss_sc::ISS_CPU::resetMethod()
 {
     reset_terminate_handler_->reset(rst_i_.read());
 }
 
-void etiss_sc::CPU::execute()
+void etiss_sc::ISS_CPU::execute()
 {
     auto etiss_status_ = etiss_core_->execute(*this);
 
@@ -396,14 +395,14 @@ void etiss_sc::CPU::execute()
     else if (etiss_status_ < 0)
     {
         std::cout << std::hex << etiss_status_ << std::dec << std::endl;
-        XREPORT("execute from CPUCore not done properly in CPU::execute()");
+        XREPORT("execute from CPUCore not done properly in ISS_CPU::execute()");
     }
 
     sc_core::sc_stop();
 }
 
-void etiss_sc::CPU::transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
-                                tlm_utils::simple_initiator_socket<CPU> &socket)
+void etiss_sc::ISS_CPU::transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
+                                tlm::tlm_initiator_socket<> &socket)
 {
     auto time_offset = getTimeOffset(cpu);
     updateSystemCTime(time_offset);
@@ -455,8 +454,8 @@ void etiss_sc::CPU::transaction(ETISS_CPU *cpu, uint64_t addr, uint8_t *buffer, 
     updateSystemCTime(time_offset);
 }
 
-uint32_t etiss_sc::CPU::dbgTransaction(uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
-                                       tlm_utils::simple_initiator_socket<CPU> &socket)
+uint32_t etiss_sc::ISS_CPU::dbgTransaction(uint64_t addr, uint8_t *buffer, uint32_t length, tlm::tlm_command cmd,
+                                           tlm::tlm_initiator_socket<> &socket)
 {
     for (auto d : dmi_objects_)
     {
@@ -484,7 +483,7 @@ uint32_t etiss_sc::CPU::dbgTransaction(uint64_t addr, uint8_t *buffer, uint32_t 
     return socket->transport_dbg(payload_);
 }
 
-void etiss_sc::CPU::dmiAccess(uint8_t *dst, uint8_t *src, unsigned len, bool flip_endianness)
+void etiss_sc::ISS_CPU::dmiAccess(uint8_t *dst, uint8_t *src, unsigned len, bool flip_endianness)
 {
     for (size_t i = 0; i < len; ++i)
     {
@@ -497,17 +496,17 @@ void etiss_sc::CPU::dmiAccess(uint8_t *dst, uint8_t *src, unsigned len, bool fli
     }
 }
 
-sc_core::sc_time etiss_sc::CPU::getTimeOffset(ETISS_CPU *cpu)
+sc_core::sc_time etiss_sc::ISS_CPU::getTimeOffset(ETISS_CPU *cpu)
 {
     return (sc_core::sc_time(cpu->cpuTime_ps, sc_core::SC_PS) - sc_core::sc_time_stamp());
 }
 
-void etiss_sc::CPU::updateCPUTime(ETISS_CPU *cpu, const sc_core::sc_time &time_offset)
+void etiss_sc::ISS_CPU::updateCPUTime(ETISS_CPU *cpu, const sc_core::sc_time &time_offset)
 {
     cpu->cpuTime_ps = (sc_core::sc_time_stamp().to_seconds() + time_offset.to_seconds()) * 1e12;
 }
 
-void etiss_sc::CPU::updateSystemCTime(sc_core::sc_time &time_offset)
+void etiss_sc::ISS_CPU::updateSystemCTime(sc_core::sc_time &time_offset)
 {
     if (sc_core::sc_time_stamp() == sc_core::SC_ZERO_TIME ||
         time_offset > sc_core::sc_time{ static_cast<double>(quantum_), sc_core::SC_PS })
@@ -517,7 +516,7 @@ void etiss_sc::CPU::updateSystemCTime(sc_core::sc_time &time_offset)
     }
 }
 
-void etiss_sc::CPU::configurePayload(uint64_t addr, tlm::tlm_command cmd, uint8_t *buffer, uint32_t length)
+void etiss_sc::ISS_CPU::configurePayload(uint64_t addr, tlm::tlm_command cmd, uint8_t *buffer, uint32_t length)
 {
     payload_.set_command(cmd);
     payload_.set_address(addr);
@@ -529,8 +528,13 @@ void etiss_sc::CPU::configurePayload(uint64_t addr, tlm::tlm_command cmd, uint8_
     payload_.set_response_status(tlm::TLM_INCOMPLETE_RESPONSE);
 }
 
+
+/************************************************************************
+ * CPU Factory                                                          *
+ ************************************************************************/
+
 etiss_sc::CPUFactory::CPUFactory(const etiss_sc::Config &cfg, etiss::Initializer *etiss_init)
-    : etiss_sc::Factory<CPU>(cfg, etiss_init)
+    : etiss_sc::Factory<ISS_CPU>(cfg, etiss_init)
 {
 }
 
@@ -545,5 +549,5 @@ void etiss_sc::CPUFactory::initParams()
 
 void etiss_sc::CPUFactory::generate(sc_core::sc_module_name name)
 {
-    genHelper<CPU, CPUParams>(name, std::move(cpu_params_));
+    genHelper<ISS_CPU, CPUParams>(name, std::move(cpu_params_));
 }

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -511,8 +511,15 @@ void etiss_sc::ISS_CPU::updateSystemCTime(sc_core::sc_time &time_offset)
     if (sc_core::sc_time_stamp() == sc_core::SC_ZERO_TIME ||
         time_offset > sc_core::sc_time{ static_cast<double>(quantum_), sc_core::SC_PS })
     {
-        wait(time_offset);
-        time_offset = sc_core::sc_time{ 0, sc_core::SC_PS };
+        if (pause_cpu_i_.read() == true)
+        {
+            wait(pause_cpu_i_.negedge_event());
+        }
+        else
+        {
+            wait(time_offset);
+            time_offset = sc_core::sc_time{ 0, sc_core::SC_PS };
+        }
     }
 }
 

--- a/src/tlm/generic/iss_cpu.cpp
+++ b/src/tlm/generic/iss_cpu.cpp
@@ -281,6 +281,11 @@ void etiss_sc::ISS_CPU::systemCallSyncTime(ETISS_CPU *cpu)
 {
     auto offset = getTimeOffset(cpu);
     updateSystemCTime(offset);
+    if (freeze_cpu_)
+    {
+        wait(wake_up_cpu_);
+        freeze_cpu_ = false;
+    }
 }
 
 etiss_int32 etiss_sc::ISS_CPU::systemCallIRead(ETISS_CPU *cpu, etiss_uint64 addr, etiss_uint32 length)


### PR DESCRIPTION
I tested the fivp with the update of this library with ri5cy and ariane core in etiss and vrtl mode.
Please test it as well before merging.

The following adjustments are necessary in the fivp to make it work:

In ri5cy_soc.cpp:
1. line 247: auto cpu = std::make_unique<etiss_sc::**ISS_CPU**>(cpu_name.c_str(), std::move(vri5cy_soc_params_.cpu_params_));
2. line 277: etiss_sc::**CPUBase** *ptr{ nullptr };

In ariane_soc.cpp:
1. line 239: auto cpu = std::make_unique<etiss_sc::**ISS_CPU**>(cpu_name.c_str(), std::move(vcva6_soc_params_.cpu_params_));
2. line 275: etiss_sc::**CPUBase** *ptr{ nullptr };